### PR TITLE
InvalidOperationException when HAL representation is missing

### DIFF
--- a/Hallo.Test/Serialization/HalJsonOutputFormatterTests.cs
+++ b/Hallo.Test/Serialization/HalJsonOutputFormatterTests.cs
@@ -175,6 +175,21 @@ namespace Hallo.Test.Serialization
             items[0]["_embedded"].Should().BeNull();
             items[0]["id"].Should().NotBeNull();
         }
+
+        [Fact]
+        public async Task OutputsStandardJsonWhenHalRepresentationIsMissing()
+        {
+            var json = await Format(new DummyModel
+            {
+                Id = 1, 
+                Property = "test"
+            });
+
+            json.Should().ContainKeys("id", "property");
+            json.Value<int>("id").Should().Be(1);
+            json.Value<string>("property").Should().Be("test");
+            json.Should().NotContainKeys("_links", "_embedded");
+        }
         
         private async Task<JObject> Format<T>(T resource)
         {

--- a/Hallo/Serialization/HalJsonOutputFormatter.cs
+++ b/Hallo/Serialization/HalJsonOutputFormatter.cs
@@ -53,7 +53,7 @@ namespace Hallo.Serialization
             var representationGenerator = GetRepresentationGenerator(context.HttpContext.RequestServices, context.ObjectType);
             if (representationGenerator == null)
             {
-                await WriteResponseBodyAsync(context);
+                await WriteResponseBodyAsync(context, Encoding.UTF8);
                 return;
             }
 


### PR DESCRIPTION
When you request `hal+json` and there is no representation registered for the requested resource the formatter calls:

```csharp
await WriteResponseBodyAsync(context);
```

The dotnet core implementation of this throws an invalid operation exception and instructs you to use the overload which accepts the encoding.

Added a test and changed to use suggested overload.