### PR TITLE
Make Json Converters Public

### DIFF
--- a/Hallo/Serialization/HalRepresentationConverter.cs
+++ b/Hallo/Serialization/HalRepresentationConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Hallo.Serialization
 {
-    internal class HalRepresentationConverter : JsonConverter<HalRepresentation>
+    public class HalRepresentationConverter : JsonConverter<HalRepresentation>
     {
         public override bool CanConvert(Type objectType) 
             => typeof(HalRepresentation).IsAssignableFrom(objectType);

--- a/Hallo/Serialization/LinksConverter.cs
+++ b/Hallo/Serialization/LinksConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Hallo.Serialization
 {
-    internal class LinksConverter : JsonConverter<IEnumerable<Link>>
+    public class LinksConverter : JsonConverter<IEnumerable<Link>>
     {
         public override IEnumerable<Link> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) 
             => throw new NotImplementedException();


### PR DESCRIPTION
This will make scenarios where the consumer would rather use RequestDelegate (e.g., in Endpoints) over controllers easier.