### PR TITLE
Use relaxed json escaping

### DIFF
--- a/Hallo.Test/Serialization/DefaultJsonSerializationOptionsTests.cs
+++ b/Hallo.Test/Serialization/DefaultJsonSerializationOptionsTests.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Hallo.Test.Serialization.Supporting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hallo.Test.Serialization
+{
+    public class DefaultJsonSerializationOptionsTests
+    {
+        private readonly ServiceCollection _services = new ServiceCollection();
+
+        [Fact]
+        public async Task UsesRelaxedCharacterEncoding()
+        {
+            _services.AddTransient<Hal<DummyModel>, DefaultRepresentation>();
+
+            var json = await TestResponseContentFormatter.FormatRaw(new DummyModel
+            {
+                Property = "+++"
+            }, _services);
+
+            json.Should().Contain("+++", because: "the 'plus' unicode character should not be escaped");
+        }
+    }
+}

--- a/Hallo.Test/Serialization/Supporting/TestResponseContentFormatter.cs
+++ b/Hallo.Test/Serialization/Supporting/TestResponseContentFormatter.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Hallo.Serialization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hallo.Test.Serialization.Supporting
+{
+    internal static class TestResponseContentFormatter
+    {
+        public static async Task<string> FormatRaw<T>(T resource, IServiceCollection services, JsonSerializerOptions jsonSerializerOptions = null)
+        {
+            var httpContext = CreateHttpContext(services);
+            var writeContext = new OutputFormatterWriteContext(httpContext, (stream, _) => new StreamWriter(stream), 
+                                                               typeof(T), resource);
+
+            var formatter = jsonSerializerOptions != null ? new HalJsonOutputFormatter(jsonSerializerOptions) : new HalJsonOutputFormatter();
+            await formatter.WriteAsync(writeContext);
+
+            var body = await ReadHttpResponseBody(httpContext);
+            return body;
+        }
+        
+        public static async Task<JObject> Format<T>(T resource, IServiceCollection services, JsonSerializerOptions jsonSerializerOptions = null)
+        {
+            var body = await FormatRaw(resource, services, jsonSerializerOptions);
+            return JsonConvert.DeserializeObject<JObject>(body);
+        }
+
+        private static DefaultHttpContext CreateHttpContext(IServiceCollection services)
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            };
+
+            httpContext.Response.Body = new MemoryStream();
+            return httpContext;
+        }
+        
+        private static async Task<string> ReadHttpResponseBody(HttpContext httpContext)
+        {
+            httpContext.Response.Body.Seek(0L, SeekOrigin.Begin);
+            using var reader = new StreamReader(httpContext.Response.Body, Encoding.UTF8);
+            
+            return await reader.ReadToEndAsync();
+        }
+    }
+}

--- a/Hallo/Serialization/HalJsonOutputFormatter.cs
+++ b/Hallo/Serialization/HalJsonOutputFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -25,13 +26,18 @@ namespace Hallo.Serialization
     public class HalJsonOutputFormatter : SystemTextJsonOutputFormatter
     {
         private const string ContentType = "application/hal+json";
+
+        private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
         
         /// <summary>
         /// Initializes a new instance of <see cref="HalJsonOutputFormatter"/> with
         /// default JSON serialization settings
         /// </summary>
         public HalJsonOutputFormatter()
-            : this(new JsonSerializerOptions()) {}
+            : this(DefaultJsonSerializerOptions) {}
         
         /// <summary>
         /// Initializes a new instance of <see cref="HalJsonOutputFormatter"/>


### PR DESCRIPTION
Fixes #45

`HalJsonOutputFormatter` has been updated to use the same encoder as `SystemTextJsonOutputFormatter` which is more relaxed with the characters it escapes. This highlighted inconsistencies between the default `JsonSerializerOptions` in the two formatters - I have raised #49 to handle this.