### PR TITLE
Disable nullable reference types

### DIFF
--- a/Hallo.AspNetCore.Mvc/Hallo.AspNetCore.Mvc.csproj
+++ b/Hallo.AspNetCore.Mvc/Hallo.AspNetCore.Mvc.csproj
@@ -16,8 +16,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Hallo.AspNetCore/Hallo.AspNetCore.csproj
+++ b/Hallo.AspNetCore/Hallo.AspNetCore.csproj
@@ -16,8 +16,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Hallo.Test/Hallo.Test.csproj
+++ b/Hallo.Test/Hallo.Test.csproj
@@ -2,13 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Hallo/Hal.cs
+++ b/Hallo/Hal.cs
@@ -37,7 +37,7 @@ namespace Hallo
             return resource ?? new object {};
         }
 
-        private static async Task<object?> EmbeddedFor(IHal representation, TResource resource)
+        private static async Task<object> EmbeddedFor(IHal representation, TResource resource)
         {
             if (representation is IHalEmbeddedAsync<TResource> asyncEmbedded)
             {

--- a/Hallo/HalRepresentation.cs
+++ b/Hallo/HalRepresentation.cs
@@ -15,7 +15,7 @@ namespace Hallo
         /// <summary>
         /// The additional resources to be embedded in the document
         /// </summary>
-        public object? Embedded { get; }
+        public object Embedded { get; }
         
         /// <summary>
         /// The hyperlinks to related resources
@@ -39,7 +39,7 @@ namespace Hallo
         /// <param name="state">The state of the requested resource</param>
         /// <param name="embedded">The additional resources to be embedded in the document</param>
         /// <param name="links">The hyperlinks to related resources</param>
-        public HalRepresentation(object state, object? embedded, IEnumerable<Link> links)
+        public HalRepresentation(object state, object embedded, IEnumerable<Link> links)
         {
             State = state;
             Embedded = embedded;

--- a/Hallo/Hallo.csproj
+++ b/Hallo/Hallo.csproj
@@ -16,8 +16,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     
     <ItemGroup>

--- a/Hallo/Link.cs
+++ b/Hallo/Link.cs
@@ -28,32 +28,32 @@ namespace Hallo
         /// <summary>
         /// A hint to indicate the media type expected when dereferencing the target resource
         /// </summary>
-        public string? Type { get; }
+        public string Type { get; }
 
         /// <summary>
         /// A URI that provides further information about the deprecation
         /// </summary>
-        public Uri? Deprecation { get; }
+        public Uri Deprecation { get; }
 
         /// <summary>
         /// A secondary key for selecting Links which share the same relation type
         /// </summary>
-        public string? Name { get; }
+        public string Name { get; }
 
         /// <summary>
         /// A URI that hints about the profile of the target resource
         /// </summary>
-        public Uri? Profile { get; }
+        public Uri Profile { get; }
 
         /// <summary>
         /// A label for the link with a human-readable identifier
         /// </summary>
-        public string? Title { get; }
+        public string Title { get; }
 
         /// <summary>
         /// The language of the target resource
         /// </summary>
-        public string? HrefLang { get; }
+        public string HrefLang { get; }
 
         /// <summary>
         /// Indicates if the hyperlink contains a URI template
@@ -71,8 +71,8 @@ namespace Hallo
         /// <param name="profile">A URI that hints about the profile of the target resource</param>
         /// <param name="title">A label for the link with a human-readable identifier</param>
         /// <param name="hrefLang">The language of the target resource</param>
-        public Link(string rel, string href, string? type = null, Uri? deprecation = null, string? name = null,
-            Uri? profile = null, string? title = null, string? hrefLang = null)
+        public Link(string rel, string href, string type = null, Uri deprecation = null, string name = null,
+            Uri profile = null, string title = null, string hrefLang = null)
         {
             if (string.IsNullOrWhiteSpace(rel))
             {

--- a/Hallo/Serialization/HalRepresentationConverter.cs
+++ b/Hallo/Serialization/HalRepresentationConverter.cs
@@ -35,7 +35,7 @@ namespace Hallo.Serialization
         private static void WriteState(Utf8JsonWriter writer, object state, JsonSerializerOptions options) 
             => WriteObjectProperties(writer, state, options);
         
-        private static void WriteEmbedded(Utf8JsonWriter writer, object? embedded, JsonSerializerOptions options)
+        private static void WriteEmbedded(Utf8JsonWriter writer, object embedded, JsonSerializerOptions options)
         {
             if (embedded == null)
             {

--- a/samples/Hallo.AspNetCore.Mvc.Sample/Hallo.AspNetCore.Mvc.Sample.csproj
+++ b/samples/Hallo.AspNetCore.Mvc.Sample/Hallo.AspNetCore.Mvc.Sample.csproj
@@ -6,8 +6,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/Hallo.AspNetCore.Sample/Hallo.AspNetCore.Sample.csproj
+++ b/samples/Hallo.AspNetCore.Sample/Hallo.AspNetCore.Sample.csproj
@@ -6,8 +6,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>true</WarningsAsErrors>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/Hallo.Giraffe.Sample/Hallo.Giraffe.Sample.fsproj
+++ b/samples/Hallo.Giraffe.Sample/Hallo.Giraffe.Sample.fsproj
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 


### PR DESCRIPTION
Nullable reference types have been enabled but the library itself has done very little to avoid nulls and simply makes types nullable. There is little value in having this option enabled and not doing anything to handle nulls differently.