### PR TITLE
write curies as an array

### DIFF
--- a/Hallo.Test/Serialization/HalJsonSerializerTests.cs
+++ b/Hallo.Test/Serialization/HalJsonSerializerTests.cs
@@ -166,5 +166,20 @@ namespace Hallo.Test.Serialization
 
             action.Should().Throw<InvalidJsonSerializerOptionsException>();
         }
+        
+        [Fact]
+        public async Task SerializerEnsuresCuriesAlwaysAnArray()
+        {
+            var json = await Serialize(new CurieRepresentation(), new DummyModel
+            {
+                Id = 123,
+                Property = "test"
+            });
+
+            var links = json.GetProperty("_links");
+            links.TryGetProperty("curies", out var curie).Should().BeTrue();
+
+            curie.GetArrayLength().Should().Be(1);
+        }
     }
 }

--- a/Hallo.Test/Serialization/Supporting/DummyModelHypermedia.cs
+++ b/Hallo.Test/Serialization/Supporting/DummyModelHypermedia.cs
@@ -87,4 +87,14 @@ namespace Hallo.Test.Serialization.Supporting
         public DummyModelListRepresentation(IHalLinks<DummyModel> linkedRepresentation) 
             : base("/dummy-model", linkedRepresentation) { }
     }
+    
+    internal class CurieRepresentation : Hal<DummyModel>,
+        IHalLinks<DummyModel>
+    {
+        public IEnumerable<Link> LinksFor(DummyModel resource)
+        {
+            yield return new Link("curies", "/docs/{rel}.html", "text/html", name: "foo", title: "Documentation",
+                hrefLang: "en");
+        }
+    }
 }

--- a/Hallo/Serialization/LinksConverter.cs
+++ b/Hallo/Serialization/LinksConverter.cs
@@ -35,7 +35,7 @@ namespace Hallo.Serialization
             {
                 writer.WritePropertyName(link.Key);
                 
-                if (link.Value.Count > 1)
+                if (link.Value.Count > 1 || link.Key == "curies")
                 {
                     WriteLinks(writer, link.Value);
                 }


### PR DESCRIPTION
when serialized, curies should be an array according to the spec - https://datatracker.ietf.org/doc/html/draft-kelly-json-hal#section-8.2